### PR TITLE
Make lib/react-router-scroll-top.js the entrypoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require("./lib/react-router-scroll-top")

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-router-scroll-top",
   "description": "An easy scroll to top component based on the React Router Scroll Restoration Example",
   "version": "0.1.0",
-  "main": "index.js",
+  "main": "lib/react-router-scroll-top.js",
   "author": "Edoardo L'Astorina",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`rollup` was failing to build my application under the current setup, presumably because of a mix between commonjs and es6 imports.
This PR fixes the issue and removes some minor redundant code